### PR TITLE
fix: support deepagents 0.4.5 summarization API

### DIFF
--- a/mirobody/pub/agents/deep/utils/constants.py
+++ b/mirobody/pub/agents/deep/utils/constants.py
@@ -99,6 +99,7 @@ MODEL_PRICING: dict[str, dict[str, float]] = {
     "claude-opus-4.5": {"input": 5.00, "output": 25.00},
     "claude-opus-4.6": {"input": 5.00, "output": 25.00},
     "claude-sonnet-4.5": {"input": 3.00, "output": 15.00},
+    "claude-sonnet-4.6": {"input": 3.00, "output": 15.00},
     "claude-haiku-4.5": {"input": 1.00, "output": 5.00},
 
     # OpenAI GPT-5 series (automatic caching, no cache_creation cost)

--- a/mirobody/pub/agents/deep_agent.py
+++ b/mirobody/pub/agents/deep_agent.py
@@ -201,11 +201,17 @@ class DeepAgent():
         2. PatchToolCallsMiddleware - Tool call fixes
         3. UniversalPromptCachingMiddleware - Prompt caching for supported models
         """
-        from deepagents.middleware.summarization import SummarizationMiddleware, _compute_summarization_defaults
+        from deepagents.middleware.summarization import SummarizationMiddleware
         from deepagents.middleware.patch_tool_calls import PatchToolCallsMiddleware
 
+        try:
+            from deepagents.middleware.summarization import compute_summarization_defaults
+        except ImportError:
+            # Backward compatibility with older deepagents releases.
+            from deepagents.middleware.summarization import _compute_summarization_defaults as compute_summarization_defaults
+
         # Compute summarization defaults based on model profile
-        summarization_defaults = _compute_summarization_defaults(llm_client)
+        summarization_defaults = compute_summarization_defaults(llm_client)
 
         summarization_middleware = SummarizationMiddleware(
             model=llm_client,

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ langchain-google-genai>=4.1.2
 langchain-google-vertexai
 langchain_community
 
-deepagents>=0.4.3
+deepagents>=0.4.5
 jinja2
 
 # Tools and so forth.


### PR DESCRIPTION
## Summary
- upgrade `deepagents` minimum version to `0.4.5`
- support both `compute_summarization_defaults` and the legacy private helper for compatibility
- add pricing metadata for `claude-sonnet-4.6`

## Verification
- `python3 -m compileall mirobody/pub/agents/deep_agent.py mirobody/pub/agents/deep/utils/constants.py`
