### PR TITLE
fix: make SQL logging optional in execute_query

### DIFF
--- a/mirobody/utils/db.py
+++ b/mirobody/utils/db.py
@@ -14,6 +14,7 @@ async def execute_query(
     db_config   : str = "",
     fieldList   : list | None = None,
     trace_id    : str = "",
+    log_sql     : bool = True,
     **kargs
 ):
     # Check SQL statement.
@@ -101,10 +102,11 @@ async def execute_query(
         if trace_id:
             extra["trace_id"] = trace_id
 
-        logged_query = " ".join(query.split())
-        if len(logged_query) > 512:
-            logged_query = logged_query[:512] + "..."
-        logging.info(logged_query, extra=extra, stacklevel=2)
+        if log_sql:
+            logged_query = " ".join(query.split())
+            if len(logged_query) > 512:
+                logged_query = logged_query[:512] + "..."
+            logging.info(logged_query, extra=extra, stacklevel=2)
 
         return ret
 


### PR DESCRIPTION
## Summary
- add a `log_sql` flag to `execute_query`
- skip SQL statement logging when callers explicitly disable it
- preserve the existing logging behavior by default

## Verification
- python -m py_compile mirobody/utils/db.py